### PR TITLE
Better element selection and handling (+ rotation fix etc.)

### DIFF
--- a/Sources/Elements.hx
+++ b/Sources/Elements.hx
@@ -429,10 +429,10 @@ class Elements {
 
 					// Hover
 					// Rotate mouse coords in opposite direction as the element
-					var hoverPoint:Vector2 = rotatePoint(ui.inputX, ui.inputY, canvas.x + ex + ew / 2, canvas.y + ey + eh / 2, -selectedElem.rotation);
+					var rotatedInput:Vector2 = rotatePoint(ui.inputX, ui.inputY, canvas.x + ex + ew / 2, canvas.y + ey + eh / 2, -selectedElem.rotation);
 
-					if (hoverPoint.x > hX && hoverPoint.x < hX + handleSize) {
-						if (hoverPoint.y > hY && hoverPoint.y < hY + handleSize) {
+					if (rotatedInput.x > hX && rotatedInput.x < hX + handleSize) {
+						if (rotatedInput.y > hY && rotatedInput.y < hY + handleSize) {
 							g.color = 0xff205d9c;
 							g.fillRect(hX, hY, handleSize, handleSize);
 							g.color = 0xffffffff;
@@ -923,8 +923,8 @@ class Elements {
 	}
 
 	function hitbox(x:Float, y:Float, w:Float, h:Float, ?rotation:Float):Bool {
-		var hoverPoint:Vector2 = rotatePoint(ui.inputX, ui.inputY, x + w / 2, y + h / 2, -rotation);
-		return hoverPoint.x > x && hoverPoint.x < x + w && hoverPoint.y > y && hoverPoint.y < y + h;
+		var rotatedInput:Vector2 = rotatePoint(ui.inputX, ui.inputY, x + w / 2, y + h / 2, -rotation);
+		return rotatedInput.x > x && rotatedInput.x < x + w && rotatedInput.y > y && rotatedInput.y < y + h;
 	}
 
 	public function update() {
@@ -961,15 +961,15 @@ class Elements {
 			var hoverAreaSize = 4;
 			if (ui.inputStarted && ui.inputDown && 
 			hitbox(canvas.x + ex - hoverAreaSize, canvas.y + ey - hoverAreaSize, ew + hoverAreaSize * 2, eh + hoverAreaSize * 2, selectedElem.rotation)) {
-				var hoverPoint:Vector2 = rotatePoint(ui.inputX, ui.inputY, canvas.x + ex + ew / 2, canvas.y + ey + eh / 2, -elem.rotation);
+				var rotatedInput:Vector2 = rotatePoint(ui.inputX, ui.inputY, canvas.x + ex + ew / 2, canvas.y + ey + eh / 2, -elem.rotation);
 
 				drag = true;
 				// Resize
 				dragLeft = dragRight = dragTop = dragBottom = false;
-				if (hoverPoint.x > canvas.x + ex + ew - hoverAreaSize) dragRight = true;
-				else if (hoverPoint.x < canvas.x + ex + hoverAreaSize) dragLeft = true;
-				if (hoverPoint.y > canvas.y + ey + eh - hoverAreaSize) dragBottom = true;
-				else if (hoverPoint.y < canvas.y + ey + hoverAreaSize) dragTop = true;
+				if (rotatedInput.x > canvas.x + ex + ew - hoverAreaSize) dragRight = true;
+				else if (rotatedInput.x < canvas.x + ex + hoverAreaSize) dragLeft = true;
+				if (rotatedInput.y > canvas.y + ey + eh - hoverAreaSize) dragBottom = true;
+				else if (rotatedInput.y < canvas.y + ey + hoverAreaSize) dragTop = true;
 
 			}
 

--- a/Sources/Elements.hx
+++ b/Sources/Elements.hx
@@ -958,17 +958,18 @@ class Elements {
 			var eh = scaled(elem.height);
 
 			// Drag selected elem
+			var hoverAreaSize = 4;
 			if (ui.inputStarted && ui.inputDown && 
-			hitbox(canvas.x + ex - 4, canvas.y + ey - 4, ew + 4, eh + 4, selectedElem.rotation)) {
+			hitbox(canvas.x + ex - hoverAreaSize, canvas.y + ey - hoverAreaSize, ew + hoverAreaSize * 2, eh + hoverAreaSize * 2, selectedElem.rotation)) {
 				var hoverPoint:Vector2 = rotatePoint(ui.inputX, ui.inputY, canvas.x + ex + ew / 2, canvas.y + ey + eh / 2, -elem.rotation);
 
 				drag = true;
 				// Resize
 				dragLeft = dragRight = dragTop = dragBottom = false;
-				if (hoverPoint.x > canvas.x + ex + ew - 4) dragRight = true;
-				else if (hoverPoint.x < canvas.x + ex + 4) dragLeft = true;
-				if (hoverPoint.y > canvas.y + ey + eh - 4) dragBottom = true;
-				else if (hoverPoint.y < canvas.y + ey + 4) dragTop = true;
+				if (hoverPoint.x > canvas.x + ex + ew - hoverAreaSize) dragRight = true;
+				else if (hoverPoint.x < canvas.x + ex + hoverAreaSize) dragLeft = true;
+				if (hoverPoint.y > canvas.y + ey + eh - hoverAreaSize) dragBottom = true;
+				else if (hoverPoint.y < canvas.y + ey + hoverAreaSize) dragTop = true;
 
 			}
 

--- a/Sources/Elements.hx
+++ b/Sources/Elements.hx
@@ -779,6 +779,12 @@ class Elements {
 			}
 
 			if (ui.tab(htab, "Preferences")) {
+				var selectMouseHandle = Id.handle({position: 0});
+				ui.combo(selectMouseHandle, ["Left Click", "Right Click"], "Select Elements With", true);
+				if (selectMouseHandle.changed) {
+					Main.prefs.selectMouseButton = ["Left", "Right"][selectMouseHandle.position];
+				}
+
 				var hscale = Id.handle({value: 1.0});
 				ui.slider(hscale, "UI Scale", 0.5, 4.0, true);
 				var gsize = Id.handle({value: 20});
@@ -790,6 +796,7 @@ class Elements {
 					ui.setScale(hscale.value);
 					windowW = Std.int(defaultWindowW * hscale.value);
 				}
+
 				Main.prefs.window_vsync = ui.check(Id.handle({selected: true}), "VSync");
 				// if (ui.button("Save")) {
 				// 	#if kha_krom
@@ -1027,7 +1034,9 @@ class Elements {
 		if (showFiles || ui.inputX > kha.System.windowWidth() - uiw) return;
 
 		// Select elem
-		if (ui.inputStarted && ui.inputDownR) {
+		var selectButton = Main.prefs.selectMouseButton;
+		if ((selectButton == "Left" || selectButton == null) && ui.inputStarted && ui.inputDown ||
+				selectButton == "Right" && ui.inputStartedR && ui.inputDownR) {
 			var i = canvas.elements.length;
 			for (elem in canvas.elements) {
 				var ex = scaled(absx(elem));

--- a/Sources/Main.hx
+++ b/Sources/Main.hx
@@ -51,4 +51,5 @@ typedef TPrefs = {
 	var path:String;
 	var scaleFactor:Float;
 	@:optional var window_vsync:Bool;
+	@:optional var selectMouseButton:String;
 }

--- a/Sources/Main.hx
+++ b/Sources/Main.hx
@@ -14,7 +14,7 @@ class Main {
 		var h = 900;
 		if (w > kha.Display.primary.width) w = kha.Display.primary.width;
 		if (h > kha.Display.primary.height - 30) h = kha.Display.primary.height - 30;
-		kha.System.start({ title : "Armory2D", width : w, height : h }, initialized);
+		kha.System.start({ title : "Armory2D", width : w, height : h, framebuffer : {samplesPerPixel : 2}}, initialized);
 	}
 	
 	static function initialized(window:kha.Window) {

--- a/Sources/Main.hx
+++ b/Sources/Main.hx
@@ -22,7 +22,7 @@ class Main {
 		prefs = { path: "", scaleFactor: 1.0 };
 
 		#if kha_krom
-		
+
 		var c = Krom.getArgCount();
 		// ./krom . . canvas_path scale_factor
 		if (c > 4) prefs.path = Krom.getArg(3);
@@ -37,13 +37,13 @@ class Main {
 			var raw:TCanvas = haxe.Json.parse(cblob.toString());
 			inst = new Elements(raw);
 		});
-		
+
 		#else
 
 		var raw:TCanvas = { name: "untitled", x: 0, y: 0, width: 1280, height: 720, elements: [], assets: [] };
 		inst = new Elements(raw);
 
-		#end		
+		#end
 	}
 }
 


### PR DESCRIPTION
### Changes:
- Element drag handles fixed & rotation support
- Element drag handles now change their color on hover (feedback)
- Added antialiasing (2 samples, I couldn't find a way to change it dynamically)
- Fixed right click selection of elements
- Added setting for element mouse selection button (Right/Left)
- The hitbox outline has a black shadow so it can be seen on light objects as well


![Screenshot](https://user-images.githubusercontent.com/17685000/64882083-9fedae00-d65c-11e9-892e-cc17d04a8a00.jpg)
_The mouse isn't shown in the screenshot_

**A few things to change in the future (possibly following PRs)/Ideas:**
- Interactive elements (buttons e.g.) don't "know" about their rotation so their hitbox is still wrong
- Buttons have an offset, but its only calculated from the left/top/right side which lets the bottom side overlap the handles (_additionally: maybe add layout elements that handle this or let the user decide about the offset?_)
- Input deltas don't work with the rotation yet. If the element is rotated by 90 degrees e.g., the (previously) bottom handle will still use the mouse y-Axis for dragging.
- Is there a way to change the mouse cursor in Kha? I couldn't find one but it would be great to change it depending on the action the user does (grabbing, dragging, ...)
- Currently there are two different variables for the handle size and the drag "area size" around the handles (I don't know how to call this, you can see it in the code) because it's calculated in different places in the code. It makes more sense to combine them, but I don't know where to put that variable then.