### PR TITLE
Support a default behaviour under Krom

### DIFF
--- a/Sources/Main.hx
+++ b/Sources/Main.hx
@@ -52,18 +52,21 @@ class Main {
 		var ar = prefs.path.split("/");
 		ar.pop();
 		cwd = ar.join("/");
-
-		var path = kha.System.systemId == "Windows" ? StringTools.replace(prefs.path, "/", "\\") : prefs.path;
-		kha.Assets.loadBlobFromPath(path, function(cblob:kha.Blob) {
-			var raw:TCanvas = haxe.Json.parse(cblob.toString());
+		
+		if(cwd != ""){
+			var path = kha.System.systemId == "Windows" ? StringTools.replace(prefs.path, "/", "\\") : prefs.path;
+			kha.Assets.loadBlobFromPath(path, function(cblob:kha.Blob) {
+				var raw:TCanvas = haxe.Json.parse(cblob.toString());
+				inst = new Editor(raw);
+			});
+		}
+		else {
+			prefs.path = Krom.getFilesLocation();
+		#end
+			var raw:TCanvas = { name: "untitled", x: 0, y: 0, width: 1280, height: 720, theme: "Default Light", elements: [], assets: [] };
 			inst = new Editor(raw);
-		});
-
-		#else
-
-		var raw:TCanvas = { name: "untitled", x: 0, y: 0, width: 1280, height: 720, theme: "Default Light", elements: [], assets: [] };
-		inst = new Editor(raw);
-
+		#if kha_krom
+		}
 		#end
 	}
 


### PR DESCRIPTION
The issue we have right now is if we don't specify the correct command to start armory2d under Krom we silently fail. This addresses this by making a similar behavior to what is done for debug_html5 when users don't specify a path to the canvas and makes i so we only need to specify the Krom folder or nothing if the exe is in the same path as the krom.js file.