### PR TITLE
Prevent transformation immediately after selecting an element

### DIFF
--- a/Sources/arm2d/ElementController.hx
+++ b/Sources/arm2d/ElementController.hx
@@ -36,6 +36,7 @@ class ElementController {
 	static var grabX = false;
 	static var grabY = false;
 	static var rotate = false;
+	static var newElementSelected = false;
 
     public static var handleSize(get, null):Int;
 	static inline function get_handleSize():Int { return Std.int(8 * ui.SCALE()); }
@@ -55,6 +56,8 @@ class ElementController {
 			// Deselect
 			var lastSelected = Editor.selectedElem;
 			Editor.selectedElem = null;
+
+			newElementSelected = false;
 
 			// Elements are sorted by z position (descending), so the topmost element will get
 			// selected if multiple elements overlap each other at the mouse position
@@ -78,6 +81,9 @@ class ElementController {
 						|| (Math.hitbox(cui, rotHandleX, rotHandleY, handleSize, rotHandleH, elem.rotation, [cx, cy]) // Rotation handle hitbox
 						    && lastSelected == elem)) { // Don't select elements other than the currently selected by their rotation handle
 					Editor.selectedElem = elem;
+
+					if (lastSelected != elem)
+						newElementSelected = true;
 					break;
 				}
 			}
@@ -176,6 +182,9 @@ class ElementController {
     public static function update(ui:Zui, cui:Zui, canvas:TCanvas) {
         arm2d.ElementController.ui = ui;
         arm2d.ElementController.cui = cui;
+
+		if (newElementSelected)
+			return;
 
         if (Editor.selectedElem != null) {
 			var elem = Editor.selectedElem;


### PR DESCRIPTION
This solves a situation where you may inadvertently transform an element when trying to select it. At the moment you have to be very deliberate when clicking to avoid this:

![before](https://user-images.githubusercontent.com/42382648/113146811-8001e900-9206-11eb-913f-5bdc81d94cbe.gif)

The solution was to simply prevent the transformation immediately after selecting the element, and thus requiring an extra step. First select, then transform.

![after](https://user-images.githubusercontent.com/42382648/113147174-e1c25300-9206-11eb-8e75-41c0efbc72de.gif)

It may be a bit cumbersome for the users that are used to this behavior, but I think it's more inconvenient having to undo (manually) unwanted transformations when trying to select elements every time if you are not careful enough, since the transform buttons are not obvious before selection.
