### PR TITLE
Fix the grid size slider

### DIFF
--- a/Sources/arm2d/Editor.hx
+++ b/Sources/arm2d/Editor.hx
@@ -54,8 +54,9 @@ class Editor {
 	public static var gridSnapPos:Bool = true;
 	public static var gridUseRelative:Bool = true;
 	public static var useRotationSteps:Bool = false;
-	public static var gridSize:Int = 20;
 	public static var rotationSteps:Float = Math.toRadians(15);
+	public static var gridSize:Int = 20;
+	public static var redrawGrid = false;
 	static var grid:kha.Image = null;
 	static var timeline:kha.Image = null;
 
@@ -118,6 +119,8 @@ class Editor {
 	}
 
 	function drawGrid() {
+		redrawGrid = false;
+
 		var scaledGridSize = scaled(gridSize);
 		var doubleGridSize = scaled(gridSize * 2);
 
@@ -126,7 +129,9 @@ class Editor {
 		var w = ww + doubleGridSize * 2;
 		var h = wh + doubleGridSize * 2;
 
-		grid = kha.Image.createRenderTarget(w, h);
+		if (grid == null) {
+			grid = kha.Image.createRenderTarget(w, h);
+		}
 		grid.g2.begin(true, 0xff242424);
 
 		for (i in 0...Std.int(h / doubleGridSize) + 1) {
@@ -203,7 +208,7 @@ class Editor {
 		var timelineFramesHeight = Std.int(40 * sc);
 
 		// Bake and redraw if the UI scale has changed
-		if (grid == null) drawGrid();
+		if (grid == null || redrawGrid) drawGrid();
 		if (timeline == null || timeline.height != timelineLabelsHeight + timelineFramesHeight) drawTimeline(timelineLabelsHeight, timelineFramesHeight);
 
 		var g = framebuffer.g2;

--- a/Sources/arm2d/ui/UIProperties.hx
+++ b/Sources/arm2d/ui/UIProperties.hx
@@ -521,6 +521,11 @@ class UIProperties {
 					ui.indent();
 					var gsize = Id.handle({value: 20});
 					ui.slider(gsize, "Grid Size", 1, 128, true, 1);
+					if (gsize.changed) {
+						Editor.gridSize = Std.int(gsize.value);
+						Editor.redrawGrid = true;
+					}
+
 					Editor.gridSnapPos = ui.check(Id.handle({selected: true}), "Grid Snap Position");
 					if (ui.isHovered) ui.tooltip("Snap the element's position to the grid");
 					Editor.gridSnapBounds = ui.check(Id.handle({selected: false}), "Grid Snap Bounds");
@@ -528,19 +533,14 @@ class UIProperties {
 					Editor.gridUseRelative = ui.check(Id.handle({selected: true}), "Use Relative Grid");
 					if (ui.isHovered) ui.tooltip("Use a grid that's relative to the selected element");
 
-					if (gsize.changed && !ui.inputDown) {
-						Editor.gridSize = Std.int(gsize.value);
-					}
-
 					Editor.useRotationSteps = ui.check(Id.handle({selected: false}), "Use Fixed Rotation Steps");
 					if (ui.isHovered) ui.tooltip("Rotate elements by a fixed step size");
 					var rotStepHandle = Id.handle({value: 15});
 					if (Editor.useRotationSteps) {
 						ui.slider(rotStepHandle, "Rotation Step Size", 1, 180, true, 1);
-					}
-
-					if (rotStepHandle.changed && !ui.inputDown) {
-						Editor.rotationSteps = Math.toRadians(rotStepHandle.value);
+						if (rotStepHandle.changed) {
+							Editor.rotationSteps = Math.toRadians(rotStepHandle.value);
+						}
 					}
 
 					ui.unindent();


### PR DESCRIPTION
One of the two slider issues mentioned in https://github.com/armory3d/armory2d/pull/70 turned out to not be a bug, but rather my fault.

After changing the grid size slider so that it reacts to all changes of the slider's value (to compensate for the slider's apparent change in functionality regarding `ui.inputDown`), it would not update the visible grid size until the slider was clicked again. This was happening because I didn't realize that changing `Editor.gridSize` would not update the grid image. One slider issue less :)